### PR TITLE
Darwin-redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,9 @@ solidgpt/src/.DS_Store
 
 # Portal
 node_modules
+
+# Local storage and workspace files
+localstorage/
+workspace/out/
+solidgpt/src/tools/qdrant/embeddings/
+solidgpt/src/tools/qdrant/embedding/

--- a/StartServer.sh
+++ b/StartServer.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# Check if the OS is macOS
+if [[ "$(uname)" == "Darwin" ]]; then
+    # Check if the Redis service is running
+    if ! pgrep redis-server > /dev/null; then
+        # If not, start Redis service using Homebrew
+        brew services start redis
+    fi
+fi
+
+
 service redis-server start
 celery -A solidgpt.src.api.celery_tasks worker --loglevel=info --detach
 uvicorn solidgpt.src.api.api:app --proxy-headers --host 0.0.0.0 --port 8000


### PR DESCRIPTION
- simple fix on the launch script to make it Darwin aware (not starting the redis server is fatal)
- add the runtime files and embeddings to the .gitignore